### PR TITLE
fix: allow paths in ngnix

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -5,6 +5,8 @@ COPY . .
 RUN npm install
 RUN npm run build
 
-FROM nginx
-
+FROM nginx as prod
+# Copy your custom nginx.conf file into the container
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Copy React Build into html folder
 COPY --from=build /app/dist /usr/share/nginx/html

--- a/client/docker-compose.yml
+++ b/client/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  frontend:
+    build: .
+    ports:
+      - 80:80
+

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
+    }
+}


### PR DESCRIPTION
# Description

Issue:
Unable to access the `/create` path on mpc.sail.codes due to an issue with Nginx configuration.

Solution:
Added a custom Nginx configuration file to allow access to all paths. Tested the fix using a local docker-compose setup.

## Checklist

- [ ] This PR can be reviewed in under 30 minutes
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned reviewers to this PR.
