### PR TITLE
feat: convert env variables to run time rather than build time

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -10,3 +10,8 @@ FROM nginx as prod
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Copy React Build into html folder
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY generate_data.sh /usr/share/nginx/html
+RUN chmod +x /usr/share/nginx/html/generate_data.sh
+
+# Execute shell script and start Nginx
+CMD ["/bin/bash", "-c", "/usr/share/nginx/html/generate_data.sh && nginx -g 'daemon off;'"]

--- a/client/generate_data.sh
+++ b/client/generate_data.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Generate JSON file
+cat > /usr/share/nginx/html/data.json <<EOF
+{
+EOF
+
+# Loop through environment variables starting with VITE_
+while IFS='=' read -r key value; do
+  if [[ "$key" == VITE_* ]]; then
+    name=$(echo "$key")
+    echo "  \"$name\": \"$value\"," >> /usr/share/nginx/html/data.json
+  fi
+done < <(env)
+
+# Complete JSON file
+cat >> /usr/share/nginx/html/data.json <<EOF
+  "timestamp": $(date +%s)
+}
+EOF

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,31 +14,34 @@ import { LogoutPage } from '@pages/logout';
 import { ApiProvider } from '@services/api';
 import { Provider } from 'react-redux';
 import store from './redux/store';
+import { SettingsProvider } from '@context/settings.context';
 
 function App() {
   return (
     <Provider store={store}>
-      <AuthProvider>
-        <SessionProvider>
-          <ApiProvider>
-            <ThemeProvider>
-              <Router>
-                <Routes>
-                  <Route element={<AdminGuard />}>
-                    <Route path={Paths.MANAGE} element={<ManagePage />} />
-                    <Route path={Paths.CREATE} element={<CreatePage />} />
-                  </Route>
-                  <Route path={Paths.HOME} element={<HomePage />} />
-                  <Route path={Paths.AUTH_CALLBACK} element={<AuthCallback />} />
-                  <Route path={Paths.PERMISSION_REQUIRED} element={<PermissionRequiredPage />} />
-                  <Route path={Paths.LOGOUT} element={<LogoutPage />} />
-                  <Route path="*" element={<Page404 />} />
-                </Routes>
-              </Router>
-            </ThemeProvider>
-          </ApiProvider>
-        </SessionProvider>
-      </AuthProvider>
+      <SettingsProvider>
+        <AuthProvider>
+          <SessionProvider>
+            <ApiProvider>
+              <ThemeProvider>
+                <Router>
+                  <Routes>
+                    <Route element={<AdminGuard />}>
+                      <Route path={Paths.MANAGE} element={<ManagePage />} />
+                      <Route path={Paths.CREATE} element={<CreatePage />} />
+                    </Route>
+                    <Route path={Paths.HOME} element={<HomePage />} />
+                    <Route path={Paths.AUTH_CALLBACK} element={<AuthCallback />} />
+                    <Route path={Paths.PERMISSION_REQUIRED} element={<PermissionRequiredPage />} />
+                    <Route path={Paths.LOGOUT} element={<LogoutPage />} />
+                    <Route path="*" element={<Page404 />} />
+                  </Routes>
+                </Router>
+              </ThemeProvider>
+            </ApiProvider>
+          </SessionProvider>
+        </AuthProvider>
+      </SettingsProvider>
     </Provider>
   );
 }

--- a/client/src/components/training-banner.tsx
+++ b/client/src/components/training-banner.tsx
@@ -1,8 +1,10 @@
 import { FC } from 'react';
 import { Alert } from '@mui/material';
+import { useSettings } from '@context/settings.context';
 
 export const TrainingBanner: FC = () => {
-  if (import.meta.env.VITE_ENV === 'training') {
+  const { VITE_ENV } = useSettings();
+  if (VITE_ENV === 'training') {
     return (
       <Alert severity="error" variant="filled" sx={{ borderRadius: 0 }}>
         This is a training environment only. Do not submit real data.

--- a/client/src/context/settings.context.tsx
+++ b/client/src/context/settings.context.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, FC, useEffect, useState } from 'react';
+
+export interface SettingsContextProps {
+  VITE_ENV: string;
+  VITE_API_BASE_URL: string;
+  VITE_SAIL_PROJECT_ID: string;
+  VITE_SAIL_AUTH_CLIENT: string;
+}
+
+const SettingsContext = createContext<SettingsContextProps>({} as SettingsContextProps);
+
+export interface SettingsProviderProps {
+  children: React.ReactNode;
+}
+
+export const SettingsProvider: FC<SettingsProviderProps> = ({ children }) => {
+  const [VITE_ENV, setVITE_ENV] = useState<string>(import.meta.env.VITE_ENV || '');
+  const [VITE_API_BASE_URL, setVITE_API_BASE_URL] = useState<string>(import.meta.env.VITE_API_BASE_URL || '');
+  const [VITE_SAIL_PROJECT_ID, setVITE_SAIL_PROJECT_ID] = useState<string>(import.meta.env.VITE_SAIL_PROJECT_ID || '');
+  const [VITE_SAIL_AUTH_CLIENT, setVITE_SAIL_AUTH_CLIENT] = useState<string>(import.meta.env.VITE_SAIL_AUTH_CLIENT || '');
+
+  useEffect(() => {
+    fetch('/data.json').then((response) => {
+      response
+        .json()
+        .then((data) => {
+          if (data.VITE_ENV) setVITE_ENV(data.VITE_ENV);
+          if (data.VITE_API_BASE_URL) setVITE_API_BASE_URL(data.VITE_API_BASE_URL);
+          if (data.VITE_SAIL_PROJECT_ID) setVITE_SAIL_PROJECT_ID(data.VITE_SAIL_PROJECT_ID);
+          if (data.VITE_SAIL_AUTH_CLIENT) setVITE_SAIL_AUTH_CLIENT(data.VITE_SAIL_AUTH_CLIENT);
+        })
+        .catch((error) => {
+          console.error('Unable to parse data.json');
+        });
+    });
+  }, []);
+
+  return (
+    <SettingsContext.Provider
+      value={{
+        VITE_ENV,
+        VITE_API_BASE_URL,
+        VITE_SAIL_PROJECT_ID,
+        VITE_SAIL_AUTH_CLIENT
+      }}
+    >
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => React.useContext(SettingsContext);

--- a/client/src/guards/admin.guard.tsx
+++ b/client/src/guards/admin.guard.tsx
@@ -2,12 +2,13 @@ import React, { FC, useEffect } from 'react';
 import { useAuth } from '@context/auth.context';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { Paths } from '@constants/paths';
+import { useSettings } from '@context/settings.context';
 
 export const AdminGuard: FC = () => {
   const { token, decodedToken, initialized } = useAuth();
+  const { VITE_SAIL_PROJECT_ID, VITE_SAIL_AUTH_CLIENT } = useSettings();
   const navigate = useNavigate();
-  const projectId = import.meta.env.VITE_SAIL_PROJECT_ID;
-  const loginUrl = `${import.meta.env.VITE_SAIL_AUTH_CLIENT}?projectId=${projectId}&redirectUrl=${encodeURIComponent(window.location.origin + Paths.AUTH_CALLBACK)}`;
+  const loginUrl = `${VITE_SAIL_AUTH_CLIENT}?projectId=${VITE_SAIL_PROJECT_ID}&redirectUrl=${encodeURIComponent(window.location.origin + Paths.AUTH_CALLBACK)}`;
 
   useEffect(() => {
     if (initialized && !token) {

--- a/client/src/services/api.tsx
+++ b/client/src/services/api.tsx
@@ -101,7 +101,6 @@ export async function createNewSubmissionUrls(count: number, sessionId: string):
   return response.data;
 }
 
-
 export async function getSubmissions(): Promise<GetEncryptedSharesResponse> {
   const response: AxiosResponse = await axios.get(API_ENDPOINTS.GET_SUBMISSIONS);
   return response.data;

--- a/client/src/services/api.tsx
+++ b/client/src/services/api.tsx
@@ -3,6 +3,7 @@ import { generateKeyPair, keyPairToDictionary } from '@utils/keypair';
 import React, { createContext, FC, useContext, useEffect } from 'react';
 import { useAuth } from '@context/auth.context';
 import { useSession } from '@context/session.context';
+import { useSettings } from '@context/settings.context';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/bwwc/';
 
@@ -61,7 +62,7 @@ export async function startSession(): Promise<CreateSessionResponse> {
   const publicKeyPem = publicKey.replace(/\n/g, '').replace('-----BEGIN PUBLIC KEY-----', '').replace('-----END PUBLIC KEY-----', '');
 
   const response: AxiosResponse<StartSessionResponse> = await axios.post(
-    `${API_BASE_URL}${API_ENDPOINTS.START_SESSION}`,
+    API_ENDPOINTS.START_SESSION,
     convertToFormData({
       public_key: publicKeyPem,
       auth_token: 'remove this later'
@@ -76,7 +77,7 @@ export async function startSession(): Promise<CreateSessionResponse> {
 
 export async function endSession(sessionId?: string): Promise<EndSessionResponse> {
   const response: AxiosResponse = await axios.post(
-    `${API_BASE_URL}${API_ENDPOINTS.END_SESSION}`,
+    API_ENDPOINTS.END_SESSION,
     convertToFormData({
       session_id: sessionId,
       auth_token: 'remove this later'
@@ -87,7 +88,7 @@ export async function endSession(sessionId?: string): Promise<EndSessionResponse
 
 export async function createNewSubmissionUrls(count: number, sessionId: string): Promise<GetSubmissionUrlsResponse> {
   const response: AxiosResponse = await axios.post(
-    `${API_BASE_URL}${API_ENDPOINTS.GET_SUBMISSION_URLS}`,
+    API_ENDPOINTS.GET_SUBMISSION_URLS,
     convertToFormData({
       session_id: sessionId,
       participant_count: count,
@@ -98,7 +99,7 @@ export async function createNewSubmissionUrls(count: number, sessionId: string):
 }
 
 export async function getEncryptedShares(): Promise<GetEncryptedSharesResponse> {
-  const response: AxiosResponse = await axios.get(`${API_BASE_URL}${API_ENDPOINTS.GET_ENCRYPTED_SHARES}`);
+  const response: AxiosResponse = await axios.get(API_ENDPOINTS.GET_ENCRYPTED_SHARES);
   return response.data;
 }
 
@@ -106,7 +107,7 @@ export async function submitData(data: any, sessionId: string, participantCode: 
   console.log(`submitting data: ${JSON.stringify(data)}`);
 
   const response: AxiosResponse = await axios.post(
-    `${API_BASE_URL}${API_ENDPOINTS.SUBMIT_DATA}`,
+    API_ENDPOINTS.SUBMIT_DATA,
     convertToFormData({
       data: JSON.stringify(data),
       sessionId: sessionId,
@@ -117,7 +118,7 @@ export async function submitData(data: any, sessionId: string, participantCode: 
 }
 
 export async function getPublicKey(session_id: string, auth_token: string): Promise<string> {
-  const response = await axios.get(`${API_BASE_URL}get_public_key/`, { params: { auth_token: auth_token, session_id: session_id } });
+  const response = await axios.get(`get_public_key/`, { params: { auth_token: auth_token, session_id: session_id } });
   return response.data.public_key;
 }
 
@@ -137,6 +138,7 @@ export interface ApiProviderProps {
 export const ApiProvider: FC<ApiProviderProps> = ({ children }) => {
   const { token } = useAuth();
   const { sessionId } = useSession();
+  const { VITE_API_BASE_URL } = useSettings();
 
   useEffect(() => {
     if (token) {
@@ -144,7 +146,8 @@ export const ApiProvider: FC<ApiProviderProps> = ({ children }) => {
     } else {
       delete axios.defaults.headers.common['Authorization'];
     }
-  }, [token]);
+    axios.defaults.baseURL = VITE_API_BASE_URL;
+  }, [token, VITE_API_BASE_URL]);
 
   return (
     <ApiContext.Provider


### PR DESCRIPTION
# Description

On start it will read from .env files or data.json which is build on the server on startup. 
This way you can change env variables on the server and use the same docker image rather than rebuilding docker image with those variables.

## Checklist

- [ ] This PR can be reviewed in under 30 minutes
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned reviewers to this PR.
