### PR TITLE
Fix: progress bar for decryption

### DIFF
--- a/backend/backend/apis/bwwc.py
+++ b/backend/backend/apis/bwwc.py
@@ -183,8 +183,9 @@ def get_submitted_data(req: HttpRequest) -> HttpResponse:
             return HttpResponseBadRequest("Invalid session ID")
 
         data = engine.get_submitted_data(session_id)
+        total_cells = engine.get_cell_count(session_id)
 
-        return JsonResponse({"data": data})
+        return JsonResponse({"data": data, "total_cells": total_cells})
     else:
         return HttpResponseBadRequest("Invalid request method")
 
@@ -206,7 +207,7 @@ def get_submission_history(req: HttpRequest) -> HttpResponse:
         return JsonResponse({"data": data})
     else:
         return HttpResponseBadRequest("Invalid request method")
-
+    
 
 def get_urlpatterns():
     return [

--- a/backend/secretshare/mpce.py
+++ b/backend/secretshare/mpce.py
@@ -218,6 +218,33 @@ class MPCEngine(object):
         for key in table1:
             result_table[key] = dfs_helper(key, table1, table2)
         return result_table
+    
+    """
+    Count the number of cells in a table.
+    
+    inputs:
+    table (Dict[str, Union[List, int]]) - the table to be counted, cells can be lists, strings or integers.
+    
+    outputs:
+    count (int) - the number of cells in the table.
+    """
+    def count_cells(self, table: Dict[str, Union[List, int]]) -> int:
+        count = 0
+
+        def dfs_helper(key: str, table: Dict[str, Any]):
+            nonlocal count
+            if isinstance(table[key], numbers.Number) or isinstance(table[key], str) or isinstance(table[key], list):
+                count += 1
+            elif isinstance(table[key], dict):
+                for k in table[key].keys():
+                    dfs_helper(k, table[key])
+            else:
+                raise Exception("Invalid table")
+
+        for key in table:
+            dfs_helper(key, table)
+
+        return count
 
     """
     Update session data with new data submitted by a participant

--- a/backend/tests/test_mpce.py
+++ b/backend/tests/test_mpce.py
@@ -121,3 +121,25 @@ def test_nested_structure():
     table2 = {"A": [6, [7, 8]], "B": [9, 10]}
     expected = {"A": [(1, 6), [(2, 7), (3, 8)]], "B": [(4, 9), (5, 10)]}
     assert engine.merge_tables(table1, table2) == expected
+
+
+def test_count_cells():
+    table = {
+        "a": 1,
+        "b": {
+            "c": "foo",
+            "d": [1, 2, 3],
+            "e": {
+                "f": "bar",
+                "g": [4, 5, 6],
+                "h": {
+                    "i": "wow",
+                    "j": {
+                        "k": [7,8,9]
+                    }
+                }
+            }
+        }
+    }
+    expected = 7
+    assert engine.count_cells(table) == expected

--- a/client/src/components/session-decrypt/decrypt-input.tsx
+++ b/client/src/components/session-decrypt/decrypt-input.tsx
@@ -83,10 +83,10 @@ export const DecryptInputForm: FC<CompanyInputFormProps> = (props) => {
       if (token !== undefined && sessionId !== undefined) {
         const fileContent = event.target?.result as string;
         const privateCryptoKey = await importPemPrivateKey(fileContent);
-        const {data, total_cells} = await getSubmissions(sessionId, token);
+        const { data, total_cells } = await getSubmissions(sessionId, token);
 
         const recordProgress = (progress: number) => {
-          setProgress(progress / total_cells * 100);
+          setProgress((progress / total_cells) * 100);
         };
 
         const decodedTable = await secretSharesToTable(data, privateCryptoKey, bigPrime, reduce, recordProgress);

--- a/client/src/components/session-decrypt/decrypt-input.tsx
+++ b/client/src/components/session-decrypt/decrypt-input.tsx
@@ -84,9 +84,13 @@ export const DecryptInputForm: FC<CompanyInputFormProps> = (props) => {
         const fileContent = event.target?.result as string;
         const privateCryptoKey = await importPemPrivateKey(fileContent);
         const {data, total_cells} = await getSubmissions(sessionId, token);
-        const decodedTable = await secretSharesToTable(data, privateCryptoKey, bigPrime, reduce, setProgress);
+
+        const recordProgress = (progress: number) => {
+          setProgress(progress / total_cells * 100);
+        };
+
+        const decodedTable = await secretSharesToTable(data, privateCryptoKey, bigPrime, reduce, recordProgress);
         dispatch(setDecodedTable(decodedTable));
-        console.log(`total_cells: ${total_cells}`)
       }
     };
 

--- a/client/src/components/session-decrypt/decrypt-input.tsx
+++ b/client/src/components/session-decrypt/decrypt-input.tsx
@@ -83,9 +83,10 @@ export const DecryptInputForm: FC<CompanyInputFormProps> = (props) => {
       if (token !== undefined && sessionId !== undefined) {
         const fileContent = event.target?.result as string;
         const privateCryptoKey = await importPemPrivateKey(fileContent);
-        const data = await getSubmissions(sessionId, token);
+        const {data, total_cells} = await getSubmissions(sessionId, token);
         const decodedTable = await secretSharesToTable(data, privateCryptoKey, bigPrime, reduce, setProgress);
         dispatch(setDecodedTable(decodedTable));
+        console.log(`total_cells: ${total_cells}`)
       }
     };
 

--- a/client/src/services/api.tsx
+++ b/client/src/services/api.tsx
@@ -54,6 +54,11 @@ export interface GetSubmissionUrlsResponse {
 
 interface GetEncryptedSharesResponse extends NestedObject {}
 
+interface GetSubmissionData {
+  data: GetEncryptedSharesResponse;
+  total_cells: number;
+}
+
 interface SubmitDataResponse {
   status: {
     [code: number]: any;
@@ -72,7 +77,7 @@ export interface ApiContextProps {
   endSession: (sessionId: string, authToken: string) => Promise<EndSessionResponse>;
   createNewSubmissionUrls: (count: number, sessionId: string, authToken: string) => Promise<GetSubmissionUrlsResponse>;
   getPublicKey: (sessionId: string) => Promise<string>;
-  getSubmissions: (sessionId: string, authToken: string) => Promise<GetEncryptedSharesResponse>;
+  getSubmissions: (sessionId: string, authToken: string) => Promise<GetSubmissionData>;
   getSubmissionHistory: (sessionId: string, authToken: string) => Promise<Submission[]>;
   stopSession: (sessionId: string, authToken: string) => Promise<StopSessionResponse>;
   submitData: (data: NestedObject, sessionId: string, participantCode: string) => Promise<AxiosResponse>;
@@ -133,9 +138,12 @@ export async function createNewSubmissionUrls(count: number, sessionId: string, 
   return response.data;
 }
 
-export async function getSubmissions(sessionId: string, authToken: string): Promise<GetEncryptedSharesResponse> {
+export async function getSubmissions(sessionId: string, authToken: string): Promise<GetSubmissionData> {
   const response: AxiosResponse = await axios.get(API_ENDPOINTS.GET_SUBMISSIONS, { params: { session_id: sessionId, auth_token: authToken } });
-  return response.data;
+  return {
+    data: response.data,
+    total_cells: response.data.total_cells
+  }
 }
 
 export async function submitData(data: NestedObject, sessionId: string, participantCode: string): Promise<AxiosResponse> {

--- a/client/src/services/api.tsx
+++ b/client/src/services/api.tsx
@@ -143,7 +143,7 @@ export async function getSubmissions(sessionId: string, authToken: string): Prom
   return {
     data: response.data,
     total_cells: response.data.total_cells
-  }
+  };
 }
 
 export async function submitData(data: NestedObject, sessionId: string, participantCode: string): Promise<AxiosResponse> {

--- a/client/src/utils/shamirs.ts
+++ b/client/src/utils/shamirs.ts
@@ -268,7 +268,7 @@ export async function secretSharesToTable(
   privateKey: CryptoKey,
   prime: BigNumber,
   reduce: (value: any) => any,
-  setProgress: (progress: number) => void
+  progressBar: (value: any) => any,
 ): Promise<Record<string, any>> {
   var counter = 0;
   const totalSteps = countSteps(obj);
@@ -291,8 +291,7 @@ export async function secretSharesToTable(
         const shares = await reduce(await decryptSecretShares(originalObj[key], privateKey));
         const reconstructed = shamirReconstruct(shares, prime, new BigNumber(0));
         currentObj[key] = reconstructed;
-        counter++;
-        setProgress((counter / totalSteps) * 100);
+        progressBar(counter++);
       } else if (typeof originalObj[key] === 'object') {
         if (!currentObj[key]) {
           currentObj[key] = {};

--- a/client/src/utils/shamirs.ts
+++ b/client/src/utils/shamirs.ts
@@ -268,7 +268,7 @@ export async function secretSharesToTable(
   privateKey: CryptoKey,
   prime: BigNumber,
   reduce: (value: any) => any,
-  progressBar: (value: any) => any,
+  progressBar: (value: any) => any
 ): Promise<Record<string, any>> {
   var counter = 0;
   const totalSteps = countSteps(obj);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "bwwc",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
# Description

Implemented backend to compute number of cells after tables are merged and return that when the analyst stops the submissions. Then pass a callback to `secretSharesToTable()` to update the progress bar.

Issue #63

## Checklist

- [x] This PR can be reviewed in under 30 minutes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have assigned reviewers to this PR.
