### PR TITLE
refactor: reduce number of shares generated to improve performance

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -21,8 +21,8 @@ export const HomePage: FC = () => {
   const [file, setFile] = useState<CustomFile | null>(null);
   const [data, setData] = useState<DataFormat>(defaultData);
   const [submitResp, setSubmitResp] = useState<AxiosResponse | undefined>();
-  const [numShares, setNumShares] = useState<number>(10);
-  const [threshold, setTheshold] = useState<number>(5); // Must have at least 5 shares to reconstruct
+  const [numShares, setNumShares] = useState<number>(3);
+  const [threshold, setTheshold] = useState<number>(1); // Must have at least 1 share to reconstruct
   const [numEncryptWithKey, setNumEncryptWithKey] = useState<number>(threshold + 1); // Encrypt amount "theshold + 1" shares with key
   const [table, setTable] = useState<Record<string, any>>({});
   const { companySize, industry, participantCode, sessionId, privateKey } = useSelector((state: AppState) => state.session);

--- a/client/src/utils/shamirs.ts
+++ b/client/src/utils/shamirs.ts
@@ -233,7 +233,6 @@ export async function tableToSecretShares(
 ): Promise<Record<string, any>> {
   const dfs = async (currentObj: Record<string, any>, originalObj: Record<string, any>): Promise<Record<string, any>> => {
     const keys = Object.keys(originalObj);
-    const encoder = new TextEncoder();
 
     for (const key of keys) {
       if (typeof originalObj[key] === 'number') {
@@ -289,7 +288,6 @@ export async function secretSharesToTable(
   }
   const dfs = async (currentObj: Record<string, any>, originalObj: Record<string, any>): Promise<Record<string, any>> => {
     const keys = Object.keys(originalObj);
-    const encoder = new TextEncoder();
 
     for (const key of keys) {
       if (Array.isArray(originalObj[key])) {


### PR DESCRIPTION
# Description

Create 3 shares with a threshold of 1 instead of 10 with a threshold of 5 to improve performance. Could just generated 2. In that case, one of the shares will be encrypted and then summed by the server effectively encrypting the shares that were not encrypted with a key. However, the current implementation is more general using the assumption that you cannot reconstruct with less than threshold number of shares.

## Checklist

- [x] This PR can be reviewed in under 30 minutes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have assigned reviewers to this PR.
